### PR TITLE
Add BSZ and KBNL

### DIFF
--- a/list.md
+++ b/list.md
@@ -20,6 +20,9 @@ Deutsche Digitale Bibliothek
 Bibliothek der Hochschule für Musik FRANZ LISZT Weimar
 [https://github.com/HfMWeimar](https://github.com/HfMWeimar)
 
+Bibliotheksservice-Zentrum Baden-Württemberg (BSZ, Konstanz)
+[https://github.com/BSZBW](https://github.com/BSZBW)
+
 Bibliotheks-Service-Zentrum
 [https://github.com/Bibliotheks-Service-Zentrum](https://github.com/Bibliotheks-Service-Zentrum)
 nur ein geforktes Repository

--- a/list.md
+++ b/list.md
@@ -154,3 +154,9 @@ René Sprotte (UB Paderborn)
 
 Michael Sievers (UB Paderborn)
 [https://github.com/msievers](https://github.com/msievers)
+
+Sonstige
+--------
+
+National Library of the Netherlands / Research
+[https://github.com/KBNLresearch](https://github.com/KBNLresearch)


### PR DESCRIPTION
This patch adds the first library outside of DACH, but I think adding other European
libraries might be a good idea (maybe the section name could be changed).