### PR TITLE
Add JabRef

### DIFF
--- a/list.md
+++ b/list.md
@@ -189,6 +189,9 @@ Austrian National Library - Department Research and Development
 Universitäts- und Landesbibliothek Sachsen-Anhalt
 [https://github.com/ulb-sachsen-anhalt](https://github.com/ulb-sachsen-anhalt)
 
+JabRef
+<https://github.com/jabref/jabref/>
+
 Developers, Librarians
 ----------------------
 


### PR DESCRIPTION
This PR adds [JabRef](https://github.com/JabRef/jabref/). JabRef is the leading open-source bibliography management software - at least in the case of BibTeX.

I decided for the `<link>` syntax (officially supported in [markdown](https://daringfireball.net/projects/markdown/syntax#autolink) and in [GitHub-flavored markdown](https://github.github.com/gfm/#autolinks))).