### PR TITLE
Add UB der OvGU Magdeburg

### DIFF
--- a/list.md
+++ b/list.md
@@ -201,6 +201,9 @@ Universitäts- und Landesbibliothek Münster
 Informationspraxis
 [https://github.com/Informationspraxis](https://github.com/Informationspraxis)
 
+Universitätsbibliothek der Otto-von-Guericke-Universität Magdeburg
+[https://github.com/ovgu-ubit](https://github.com/ovgu-ubit)
+
 
 Developers, Librarians
 ----------------------


### PR DESCRIPTION
It seems that this new account @ovgu-ubit is user account rather than an organization. However, the name seems to be (after some thought) clearly to indicate that this is the organization and not a single user. Therefore I added it under the institution category.