### PR TITLE
add eth library lab to list.md

### DIFF
--- a/list.md
+++ b/list.md
@@ -208,6 +208,8 @@ Kooperativer Bibliotheksverbund Berlin-Brandenburg (KOBV)
 [https://github.com/opus4](https://github.com/opus4)
 [https://github.com/oa-deepgreen](https://github.com/oa-deepgreen)
 
+ETH Library Lab, Zürich CH
+[https://github.com/eth-library-lab](https://github.com/eth-library-lab)
 
 Developers, Librarians
 ----------------------


### PR DESCRIPTION
Thanks for maintaining this list. 
Would love to add the github site for our innovation lab from the Library of ETH Zürich.