### PR TITLE
Update repo url for "University Library of Bern"

### DIFF
--- a/list.md
+++ b/list.md
@@ -153,7 +153,7 @@ Staats- und Universitätsbibliothek Hamburg
 [https://github.com/subhh](https://github.com/subhh)
 
 Bern University Library
-[https://github.com/UB-Bern](https://github.com/UB-Bern)
+[https://github.com/ub-unibe-ch](https://github.com/ub-unibe-ch)
 
 Universitätsbibliothek der Technischen Universität Wien
 [https://github.com/UBTUW](https://github.com/UBTUW)


### PR DESCRIPTION
https://github.com/UB-Bern is no longer in use.
The correct enterprise account is https://github.com/ub-unibe-ch
As proof you can check the description text under https://github.com/UB-Bern or check the forward of transferred repositories (e.g. https://github.com/UB-Bern/zotero-swissbib-bb-locations).